### PR TITLE
Sharing a few fixes I am using on my fork

### DIFF
--- a/llm_lmstudio.py
+++ b/llm_lmstudio.py
@@ -19,6 +19,7 @@ raw = (os.getenv("LMSTUDIO_API_BASE")       # singular, supports comma-separated
        or "http://localhost:1234")             # hard default
 SERVER_LIST = [u.strip().rstrip("/") for u in raw.split(",") if u.strip()]
 TIMEOUT = float(os.getenv("LMSTUDIO_TIMEOUT", 10))
+LLM_LMSTUDIO_TTL = os.getenv("LLM_LMSTUDIO_TTL")
 
 # --------------------------------------------------------------------------- #
 #  Internal helpers                                                           #
@@ -101,7 +102,7 @@ def register_models(register):
 
             raw_id = m['id']
             if single_server:
-                model_id = raw_id
+                model_id = f"lmstudio/{raw_id}"
             else:
                 model_id = f"lmstudio@{_host_tag(base)}/{raw_id}"
 
@@ -259,6 +260,8 @@ class LMStudioModel(LMStudioBaseModel):
             # Assume the first server is the first server to load the model from
             server = urlparse(SERVER_LIST[0])
             lms_load_cmd = ["lms", "load", "--exact", self.raw_id, "--host", server.hostname, "--port", str(server.port)]
+            if LLM_LMSTUDIO_TTL is not None:
+                lms_load_cmd = lms_load_cmd + ["--ttl", LLM_LMSTUDIO_TTL]
             if debug_enabled:
                 print(f"Running command '{lms_load_cmd}'", file=sys.stderr)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llm-lmstudio"
-version = "0.1.0"
+version = "0.2.0"
 description = "LLM plugin for models served by LMStudio (local LLM studio HTTP API)"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [{ name = "Agusti" }]


### PR DESCRIPTION
Let me know if you are interested in any of these separated out. I find them all quite useful.

1. Prepend `lmstudio/` to all model names. Without this, I find it confusing to know exactly which models are these local models versus those from other plugins.
2. Increase the default timeout to 10 from 4
3. Add `LLM_LMSTUDIO_TTL` and pass through to `lms load` command. This lets LMStudio know when to unload models. Very useful for running evals across different models, otherwise my machine tries to have too many models loaded at the same time.
4. Add --host, --port flags to lms load call to support non-localhost `LMSTUDIO_API_BASE` values (also opened as PR #8)